### PR TITLE
onLoadFont errors are no longer fatal to instantiation

### DIFF
--- a/lib/loadFonts.js
+++ b/lib/loadFonts.js
@@ -76,12 +76,12 @@ define([
           , fontInfo = []
           ;
         for(i=0,l=fontFiles.length;i<l;i++) {
-            if (fontFiles[i]) {
-                fontInfo.push({
-                    name: fontFiles[i]
-                    , url: fontFiles[i]
-                });
-            }
+            if (!fontFiles[i])
+                throw new Error('The url at index '+i+' appears to be invalid.');
+            fontInfo.push({
+                name: fontFiles[i]
+                , url: fontFiles[i]
+            });
         }
         _loadFonts(pubsub, fontInfo, loadFromUrl);
     }

--- a/lib/loadFonts.js
+++ b/lib/loadFonts.js
@@ -6,18 +6,35 @@ define([
     "use strict";
     /*globals FileReader, XMLHttpRequest, console*/
 
+    /**
+     * Callback for when a fontfile has been loaded
+     *
+     * @param i: index of the font loaded
+     * @param fontFileName
+     * @param err: null or string with error message
+     * @param fontArraybuffer
+     */
     function onLoadFont(i, fontFileName, err, fontArraybuffer) {
+        var error = !(err === null);
         /* jshint validthis: true */
-        if(err) {
-            console.warn('Can\'t load font', fontFileName, ' with error:', err);
-            return;
+        try {
+            var font = opentype.parse(fontArraybuffer);
+        } catch (e) {
+            error = e;
         }
-        var font = opentype.parse(fontArraybuffer);
-        this.pubsub.publish('loadFont', i, fontFileName, font, fontArraybuffer);
-        this.countLoaded += 1;
-        // if there was an error loading a font (above) this will never run
-        if(this.countLoaded === this.countAll)
+
+        if (error !== false) {
+            console.warn('Can\'t load font', fontFileName, ' with error:', error);
+            this.countAll--;
+        } else {
+            this.pubsub.publish('loadFont', i, fontFileName, font, fontArraybuffer);
+            this.countLoaded += 1;
+            // if there was an error loading a font (above) this will never run
+        }
+        if(this.countLoaded === this.countAll) {
+            console.log("allFontsLoaded");
             this.pubsub.publish('allFontsLoaded', this.countAll);
+        }
     }
 
     function loadFromUrl(fontInfo, callback) {

--- a/lib/loadFonts.js
+++ b/lib/loadFonts.js
@@ -15,21 +15,20 @@ define([
      * @param fontArraybuffer
      */
     function onLoadFont(i, fontFileName, err, fontArraybuffer) {
-        var error = err;
+        var font;
         /* jshint validthis: true */
-        try {
-            var font = opentype.parse(fontArraybuffer);
-        } catch (e) {
-            error = e;
-        }
-
-        if (error) {
-            console.warn('Can\'t load font', fontFileName, ' with error:', error);
+        if(err) {
+            console.warn('Can\'t load font', fontFileName, ' with error:', err);
             this.countAll--;
-        } else {
+        }
+        try {
+            font = opentype.parse(fontArraybuffer);
             this.pubsub.publish('loadFont', i, fontFileName, font, fontArraybuffer);
             this.countLoaded += 1;
             // if there was an error loading a font (above) this will never run
+        } catch (parseError) {
+            console.warn('Can\'t load font', fontFileName, ' with error:', parseError);
+            this.countAll--;
         }
         if(this.countLoaded === this.countAll) {
             this.pubsub.publish('allFontsLoaded', this.countAll);
@@ -77,10 +76,12 @@ define([
           , fontInfo = []
           ;
         for(i=0,l=fontFiles.length;i<l;i++) {
-            fontInfo.push({
-                name: fontFiles[i]
-              , url: fontFiles[i]
-            });
+            if (fontFiles[i]) {
+                fontInfo.push({
+                    name: fontFiles[i]
+                    , url: fontFiles[i]
+                });
+            }
         }
         _loadFonts(pubsub, fontInfo, loadFromUrl);
     }

--- a/lib/loadFonts.js
+++ b/lib/loadFonts.js
@@ -11,11 +11,11 @@ define([
      *
      * @param i: index of the font loaded
      * @param fontFileName
-     * @param err: null or string with error message
+     * @param err: null, error-object or string with error message
      * @param fontArraybuffer
      */
     function onLoadFont(i, fontFileName, err, fontArraybuffer) {
-        var error = !(err === null);
+        var error = err;
         /* jshint validthis: true */
         try {
             var font = opentype.parse(fontArraybuffer);
@@ -23,7 +23,7 @@ define([
             error = e;
         }
 
-        if (error !== false) {
+        if (error) {
             console.warn('Can\'t load font', fontFileName, ' with error:', error);
             this.countAll--;
         } else {
@@ -32,7 +32,6 @@ define([
             // if there was an error loading a font (above) this will never run
         }
         if(this.countLoaded === this.countAll) {
-            console.log("allFontsLoaded");
             this.pubsub.publish('allFontsLoaded', this.countAll);
         }
     }


### PR DESCRIPTION
Previously a faulty passed in font (not a opentype font, invalid file name) would cause opentype.js fail and halt script execution. I slightly modified `onLoadFont` to handle those cases more gracefully with a console error message and proceeding to still load the other fonts. Not perfect, but better than failing outright.