### PR TITLE
Added check to ensure FontsData.js doesn't break on fonts without scr…

### DIFF
--- a/lib/services/FontsData.js
+++ b/lib/services/FontsData.js
@@ -97,35 +97,32 @@ define([
 
     FontsData.getFeatures = function getFeatures(font) {
         // get all gsub features:
-        if('gsub' in font.tables) {
-            var table = font.tables.gsub
-              , scripts = font.tables.gsub.scripts
-              , features = {/*tag: ["{script:lang}", {script:lang}]*/}
-              , i, l, j, m, script, scriptTag, lang
-              ;
-
-            if (scripts) {
-                for(i=0,l=scripts.length;i<l;i++) {
-                    script = scripts[i].script;
-                    scriptTag = scripts[i].tag;
-                    if(script.defaultLangSys) {
-                        lang = 'Default';
-                        FontsData._getFeatures.call(features
-                          , table.features
-                          , [scriptTag, lang].join(':')
-                          , script.defaultLangSys.featureIndexes
-                        );
-                    }
-                    if(script.langSysRecords) {
-                        for(j = 0, m = script.langSysRecords.length; j < m; j++) {
-                            lang = script.langSysRecords[j].tag;
-                            FontsData._getFeatures.call(features
-                              , table.features
-                              , [scriptTag, lang].join(':')
-                              , script.langSysRecords[j].langSys.featureIndexes
-                            );
-                        }
-                    }
+        var features = {/*tag: ["{script:lang}", {script:lang}]*/}
+          ,  table, scripts, i, l, j, m, script, scriptTag, lang
+          ;
+        if(!('gsub' in font.tables) || !font.tables.gsub.scripts)
+            return features;
+        table = font.tables.gsub;
+        scripts = font.tables.gsub.scripts;
+        for(i=0,l=scripts.length;i<l;i++) {
+            script = scripts[i].script;
+            scriptTag = scripts[i].tag;
+            if(script.defaultLangSys) {
+                lang = 'Default';
+                FontsData._getFeatures.call(features
+                  , table.features
+                  , [scriptTag, lang].join(':')
+                  , script.defaultLangSys.featureIndexes
+                );
+            }
+            if(script.langSysRecords) {
+                for(j = 0, m = script.langSysRecords.length; j < m; j++) {
+                    lang = script.langSysRecords[j].tag;
+                    FontsData._getFeatures.call(features
+                      , table.features
+                      , [scriptTag, lang].join(':')
+                      , script.langSysRecords[j].langSys.featureIndexes
+                    );
                 }
             }
             return features;

--- a/lib/services/FontsData.js
+++ b/lib/services/FontsData.js
@@ -104,25 +104,27 @@ define([
               , i, l, j, m, script, scriptTag, lang
               ;
 
-            for(i=0,l=scripts.length;i<l;i++) {
-                script = scripts[i].script;
-                scriptTag = scripts[i].tag;
-                if(script.defaultLangSys) {
-                    lang = 'Default';
-                    FontsData._getFeatures.call(features
-                        , table.features
-                        , [scriptTag, lang].join(':')
-                        , script.defaultLangSys.featureIndexes
-                    );
-                }
-                if(script.langSysRecords) {
-                    for(j=0,m=script.langSysRecords.length;j<m;j++){
-                        lang = script.langSysRecords[j].tag;
+            if (scripts) {
+                for(i=0,l=scripts.length;i<l;i++) {
+                    script = scripts[i].script;
+                    scriptTag = scripts[i].tag;
+                    if(script.defaultLangSys) {
+                        lang = 'Default';
                         FontsData._getFeatures.call(features
-                            , table.features
-                            , [scriptTag, lang].join(':')
-                            , script.langSysRecords[j].langSys.featureIndexes
+                          , table.features
+                          , [scriptTag, lang].join(':')
+                          , script.defaultLangSys.featureIndexes
                         );
+                    }
+                    if(script.langSysRecords) {
+                        for(j = 0, m = script.langSysRecords.length; j < m; j++) {
+                            lang = script.langSysRecords[j].tag;
+                            FontsData._getFeatures.call(features
+                              , table.features
+                              , [scriptTag, lang].join(':')
+                              , script.langSysRecords[j].langSys.featureIndexes
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…ipt tables

I was working on a alternative rendering of opentype feature and wanted to test reacting to a font that doesn't have any opentype features (however unlikely that is). On using such a font, I noticed that FontsData.js [assumes a scripts table](https://github.com/graphicore/specimenTools/blob/master/lib/services/FontsData.js#L107) to be present in the code, and throws an error when there isn't. I simply wrapped that check in an if to avoid failure - maybe there is further actions that should be taken?