### PR TITLE
Added possibility to overwrite font names as per #23

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,8 +19,11 @@
   ],
   "dependencies": {
     "Atem-Pen-Case": "graphicore/Atem-Pen-Case",
-    "opentype.js": "~0.6.5",
+    "opentype.js": "^0.7.3",
     "requirejs": "~2.3.2",
     "requirejs-text": "~2.0.15"
+  },
+  "resolutions": {
+    "opentype.js": "^0.7.3"
   }
 }

--- a/examples/simple/main.js
+++ b/examples/simple/main.js
@@ -35,7 +35,15 @@ define([
         // dependant on the state of another module.
         var pubsub = new PubSub()
           , factories
-          , fontsData = new FontsData(pubsub, {useLaxDetection: true})
+          , fontsData = new FontsData(pubsub, {
+              useLaxDetection: true, 
+
+              // passing in this object with a font's postscript name
+              // allows this name to be overwritten
+              overwrites: { 
+                'JosefinSans': 'Testname: Josefin Sans' 
+              } 
+            })
           , webFontProvider = new WebFontProvider(window, pubsub, fontsData)
           ;
 

--- a/lib/services/FontsData.js
+++ b/lib/services/FontsData.js
@@ -265,7 +265,10 @@ define([
                         || font.names.fontFamily
                         ;
         fontFamily = fontFamily.split('-')[0];
-        return fontFamily;
+        fontFamily = typeof this._options.overwrites[fontFamily] === "string" 
+            ? this._options.overwrites[fontFamily] : fontFamily;
+
+        return fontFamily
     };
 
     _p._getOS2FontWeight = function(fontIndex) {

--- a/lib/services/FontsData.js
+++ b/lib/services/FontsData.js
@@ -265,8 +265,10 @@ define([
                         || font.names.fontFamily
                         ;
         fontFamily = fontFamily.split('-')[0];
-        fontFamily = typeof this._options.overwrites[fontFamily] === "string" 
-            ? this._options.overwrites[fontFamily] : fontFamily;
+        
+        if (typeof this._options.overwrites === "object" && typeof this._options.overwrites[fontFamily] === "string") {
+                fontFamily = this._options.overwrites[fontFamily]
+        }
 
         return fontFamily
     };


### PR DESCRIPTION
Also updated opentype.js to a newer version which fixes a couple of inconvenient bugs.

This is pretty straight forward; FontsData can be passed a addition overwrites option which contains keys equalling a font's PS name, and the value is an overwrite for that name. I've not expanded this to overwriting anything else, like weights or widths, but the possibility to overwrite the name can come in handy in many ways. My use case is showing a type tester with several fonts (all of the same family), so I'd like to manually overwrite all names to be merely the style, not family name plus style. Furthermore, font names would look nicer with additional spaces etc, all of which can be tweaked with passing these in as options.