### PR TITLE
Added support for mordern weight values starting with 100

### DIFF
--- a/lib/services/FontsData.js
+++ b/lib/services/FontsData.js
@@ -9,8 +9,14 @@ define([
     /*jshint esnext:true*/
 
     var weight2weightName = {
-            250: 'Thin'
+          // "modern" weight values starting from 100
+            100: 'Thin'
+          , 200: 'Light'
+
+          // conventional "windows-safe" weight values
+          , 250: 'Thin'
           , 275: 'ExtraLight'
+
           , 300: 'Light'
           , 400: 'Regular'
           , 500: 'Medium'
@@ -18,13 +24,20 @@ define([
           , 700: 'Bold'
           , 800: 'ExtraBold'
           , 900: 'Black'
-          // bad values (found first in WorkSans)
+
+          // misc bad values (found first in WorkSans)
           , 260: 'Thin'
           , 280: 'ExtraLight'
         }
       , weight2cssWeight = {
-            250: '100'
+          // "modern" weight values starting from 100
+            100: '100'
+          , 200: '200'
+
+          // conventional "windows-safe" weight values
+          , 250: '100'
           , 275: '200'
+
           , 300: '300'
           , 400: '400'
           , 500: '500'
@@ -32,7 +45,8 @@ define([
           , 700: '700'
           , 800: '800'
           , 900: '900'
-          // bad values (found first in WorkSans)
+
+          // misc bad values (found first in WorkSans)
           , 260: '100'
           , 280: '200'
         }


### PR DESCRIPTION
This adds support for weight classes that don't adhere to the windows imposed restrictions for light weights and go down beyond the 200. I've encountered this with several users that have generated their webfonts to match the css weights, and then been confused when the detection through specimen tools fails.

This doesn't catch weight values inbetween hundreds, which I've also seen. For those we could eventually throw an error or warning, but this PR catches some more common weight classes, based on the designers interpretation of that value.