### PR TITLE
Keeping track of loaded and loading fonts to avoid duplicate XHRs for same files

### DIFF
--- a/lib/loadFonts.js
+++ b/lib/loadFonts.js
@@ -6,6 +6,14 @@ define([
     "use strict";
     /*globals FileReader, XMLHttpRequest, console*/
 
+    /* Keep track of what is already in queue for being loaded or has already
+     * been loaded; in those cases don't initiate another XHR, but:
+     * - executed the callback store in queued
+     * - reuse the fontbuffer in loaded
+     */ 
+    var queue = {},
+        loaded = {};
+
     /**
      * Callback for when a fontfile has been loaded
      *
@@ -16,7 +24,13 @@ define([
      */
     function onLoadFont(i, fontFileName, err, fontArraybuffer) {
         /* jshint validthis: true */
-        var font;
+        var font
+          , isLoaded = Object.keys(loaded).indexOf(fontFileName) !== -1
+          ;
+
+        if (isLoaded)
+            fontArraybuffer = loaded[ fontFileName ];
+
         if(!err) {
             try {
                 font = opentype.parse(fontArraybuffer);
@@ -35,8 +49,18 @@ define([
             this.countLoaded += 1;
         }
 
-        if(this.countLoaded === this.countAll)
+        loaded[ fontFileName ] = fontArraybuffer;
+
+        if (!isLoaded) {
+            for (var c=0; c<queue[fontFileName].length; c++) {
+                queue[fontFileName][c]();
+            }
+        }
+
+        if(this.countLoaded === this.countAll) {
             this.pubsub.publish('allFontsLoaded', this.countAll);
+        }
+
 
     }
 
@@ -83,6 +107,7 @@ define([
         for(i=0,l=fontFiles.length;i<l;i++) {
             if (!fontFiles[i])
                 throw new Error('The url at index '+i+' appears to be invalid.');
+
             fontInfo.push({
                 name: fontFiles[i]
                 , url: fontFiles[i]
@@ -92,6 +117,8 @@ define([
     }
 
     function _loadFonts(pubsub, fontFiles, loadFont) {
+        // console.log("_loadFonts", fontFiles)
+
         var i, l, fontInfo, onload
           , loaderState = {
                 countLoaded: 0
@@ -102,12 +129,39 @@ define([
 
         for(i=0,l=fontFiles.length;i<l;i++) {
             fontInfo = fontFiles[i];
-            pubsub.publish('prepareFont', i, fontInfo.name, l);
+
+            var isQueued = Object.keys(queue).indexOf(fontInfo.name) !== -1
+              , isLoaded = Object.keys(loaded).indexOf(fontInfo.name) !== -1
+              ;
+
             onload = onLoadFont.bind(loaderState, i, fontInfo.name);
+
+            if (isLoaded) {
+                // is a file is already loaded, simply execute the callback
+                // the arraybuffer form the previous XHR for this file is stored
+                // and used to construct the opentype font object
+                onload();
+                continue;
+            }
+
+            if (isQueued) {
+                // if this file is already set to load add this callback to the
+                // be executed when the load finishes
+                queue[ fontInfo["name"] ].push( onload );
+                continue;
+            }
+
+            // For the first time this file gets loaded simply add the key to 
+            // the queue and execute the load (and subsequent callback)
+            queue[ fontInfo["name"] ] = [];
+
             // The timeout thing is handy to slow down the load progress,
             // if development is done on that part.
             // setTimeout(function(fontInfo, onload) {
-            loadFont(fontInfo, onload);
+
+                pubsub.publish('prepareFont', i, fontInfo.name, l);
+                loadFont(fontInfo, onload);
+
             // }.bind(null, fontInfo, onload), Math.random() * 5000);
         }
     }


### PR DESCRIPTION
In my use of the library one recurring performance problem is the XHR based font loading, which does not cache the request and so might re-load a font file several times on a page. E.g. a family page that has each style as a tester you can type with, but also all other styles available via a dropdown would load each style for as many times as there is styles, so instead of say 8 x 30kb it might be 64 x 30kb!

This PR logs what files have been loaded or are being loaded and circumvents duplicate XHR requests, so each unique file path is at most loaded only once.

If several instances load the same file on startup, the "queue"ing comes into effect. If fonts are loaded after the initial setup (not a common scenario with one initial setup, but possible), the "loaded" checks come into effect.

You can test this by changing the fonts being loaded in the multiple example to have the same file in several of the font lists. Using the multiple example's main.js `loadFonts.fromUrl(pubsub, fontFilesForInstance);` call in main() inside a timeout for a second time demos the reaction to already loaded files.