### PR TITLE
Also added 'oblique' subfamily identifier to manual italic detection

### DIFF
--- a/lib/services/FontsData.js
+++ b/lib/services/FontsData.js
@@ -299,7 +299,7 @@ define([
         var font = this._data[fontIndex].font
           , italicFromOS2 = !!(font.tables.os2.fsSelection & font.fsSelectionValues.ITALIC)
           , subFamily = this.getSubfamilyName(fontIndex).toLowerCase()
-          , italicFromName = subFamily.indexOf("italic") !== -1
+          , italicFromName = subFamily.indexOf("italic") !== -1 || subFamily.indexOf("oblique") !== -1
           ;
         return italicFromOS2 || italicFromName;
     };


### PR DESCRIPTION
I've encountered myself and via feedback from users that also Oblique styles often fail to detect as "italic" from the PS entries. Expanding on the manual italic detection by extracting the "italic" string from the style name I've added checks for "oblique". 

Failing to extract the italic bit causes the "italic"/"oblique" and the roman to be conflated and displayed incorrectly, in addition to a warning about duplicate font warning. 

The PR should have no negative impact for fonts with correctly denoted PS table, but also catch some more spotty fonts.