### PR TITLE
More extensive overwrites via object pass in

### DIFF
--- a/examples/simple/main.js
+++ b/examples/simple/main.js
@@ -38,10 +38,22 @@ define([
           , fontsData = new FontsData(pubsub, {
               useLaxDetection: true, 
 
-              // passing in this object with a font's postscript name
-              // allows this name to be overwritten
+              // passing in this object with overwrites per font file gets
+              // applied on top of the parsed opentype font object and overwrites
+              // only those properties defined
               overwrites: { 
-                'JosefinSans': 'Testname: Josefin Sans' 
+                '../../assets/fonts/Jura-Medium.ttf': {
+                  'names': {
+                    'postScriptName':  {
+                      'en': 'Jura overwritten'
+                    }
+                  },
+                  'tables': {
+                    'os2': {
+                      'usWeightClass': 400
+                    }
+                  }
+                }
               } 
             })
           , webFontProvider = new WebFontProvider(window, pubsub, fontsData)

--- a/lib/loadFonts.js
+++ b/lib/loadFonts.js
@@ -4,7 +4,62 @@ define([
     opentype
 ) {
     "use strict";
-    /*globals FileReader, XMLHttpRequest, console*/
+    /*globals setTimeout, FileReader, XMLHttpRequest, console*/
+
+    function _publishLoaded(task, data) {
+        var state = task.state
+          , index = task.index
+          , fontFileName = task.name
+          , err = data.error
+          , font = data.font
+          , fontArraybuffer = data.arraybuffer
+          ;
+
+        if(err) {
+            console.warn('Can\'t load font', fontFileName, ' with error:', err);
+            state.countAll--;
+        }
+        else {
+            state.pubsub.publish('loadFont', index, fontFileName, font, fontArraybuffer);
+            state.countLoaded += 1;
+        }
+
+        if(state.countLoaded === state.countAll)
+            state.pubsub.publish('allFontsLoaded', state.countAll);
+    }
+
+    function _getLoadedFontData(err, fontArraybuffer) {
+        var err_ = err || null
+          , font = null
+          ;
+        if(!err) {
+            try {
+                font =  opentype.parse(fontArraybuffer);
+            }
+            catch (parseError) {
+                err_ = parseError;
+            }
+        }
+
+        return {
+            error:err_
+          , font: font
+          , arraybuffer:fontArraybuffer
+        };
+    }
+
+    function _onLoadQueued(cache, key, err, fontArraybuffer) {
+        var data, queue, i, l, task;
+
+        cache.loaded[key] = data = _getLoadedFontData(err, fontArraybuffer);
+        queue = cache.queues[key];
+        delete cache.queues[key];
+
+        for(i=0,l=queue.length;i<l;i++) {
+            task = queue[i];
+            _publishLoaded(task, data);
+        }
+    }
 
     /**
      * Callback for when a fontfile has been loaded
@@ -14,30 +69,9 @@ define([
      * @param err: null, error-object or string with error message
      * @param fontArraybuffer
      */
-    function onLoadFont(i, fontFileName, err, fontArraybuffer) {
-        /* jshint validthis: true */
-        var font;
-        if(!err) {
-            try {
-                font = opentype.parse(fontArraybuffer);
-            }
-            catch (parseError) {
-                err = parseError;
-            }
-        }
-
-        if(err) {
-            console.warn('Can\'t load font', fontFileName, ' with error:', err);
-            this.countAll--;
-        }
-        else {
-            this.pubsub.publish('loadFont', i, fontFileName, font, fontArraybuffer);
-            this.countLoaded += 1;
-        }
-
-        if(this.countLoaded === this.countAll)
-            this.pubsub.publish('allFontsLoaded', this.countAll);
-
+    function _onLoadFont(task, err, fontArraybuffer) {
+        var data = _getLoadedFontData(err, fontArraybuffer);
+        _publishLoaded(task, data);
     }
 
     function loadFromUrl(fontInfo, callback) {
@@ -75,8 +109,7 @@ define([
     }
     loadFontsFromFileInput.needsPubSub = true;
 
-
-    function loadFontsFromUrl(pubsub, fontFiles) {
+    function loadFontsFromUrl(pubsub, fontFiles, cache) {
         var i, l
           , fontInfo = []
           ;
@@ -84,31 +117,66 @@ define([
             if (!fontFiles[i])
                 throw new Error('The url at index '+i+' appears to be invalid.');
             fontInfo.push({
-                name: fontFiles[i]
+                  name: fontFiles[i]
                 , url: fontFiles[i]
+                // this is for the cache and must be the same as url in this case,
+                // to ensure we request a file only once
+                , key: fontFiles[i]
             });
         }
-        _loadFonts(pubsub, fontInfo, loadFromUrl);
+        _loadFonts(pubsub, fontInfo, loadFromUrl, cache);
     }
 
-    function _loadFonts(pubsub, fontFiles, loadFont) {
-        var i, l, fontInfo, onload
+    function _initCache(cache) {
+        if(!('loaded' in cache))
+            cache.loaded = Object.create(null);
+        if(!('queues' in cache))
+            cache.queues = Object.create(null);
+    }
+
+    function _loadFonts(pubsub, fontFiles, loadFont, cache) {
+        var i, l, fontInfo, key, onload, task, data
           , loaderState = {
                 countLoaded: 0
               , countAll: fontFiles.length
               , pubsub: pubsub
             }
           ;
+        if(cache)
+            _initCache(cache);
 
+        filesLoop:
         for(i=0,l=fontFiles.length;i<l;i++) {
             fontInfo = fontFiles[i];
             pubsub.publish('prepareFont', i, fontInfo.name, l);
-            onload = onLoadFont.bind(loaderState, i, fontInfo.name);
-            // The timeout thing is handy to slow down the load progress,
-            // if development is done on that part.
-            // setTimeout(function(fontInfo, onload) {
-            loadFont(fontInfo, onload);
-            // }.bind(null, fontInfo, onload), Math.random() * 5000);
+            task = {
+                state: loaderState
+              , index: i
+              , name: fontInfo.name
+            };
+            onload = null;
+            if(cache) {
+                key = fontInfo.key;
+                if(key in cache.loaded) {
+                    data = cache.loaded[key];
+                    // execute async
+                    setTimeout(_publishLoaded.bind(null, task, data), 0);
+                    continue filesLoop;
+                }
+                // put into queue
+                if(!(key in cache.queues)) {
+                    // initiate queue
+                    cache.queues[key] = [];
+                    onload = _onLoadQueued.bind(null, cache, key);
+                }
+                cache.queues[key].push(task);
+            }
+            else // no cache
+                onload = _onLoadFont.bind(null, task);
+
+            // if no cache or of queue was just initiated
+            if(onload)
+                loadFont(fontInfo, onload);
         }
     }
 

--- a/lib/services/FontsData.js
+++ b/lib/services/FontsData.js
@@ -226,6 +226,11 @@ define([
     };
 
     _p._onLoadFont = function(fontIndex, fontFileName, font, originalArraybuffer) {
+        // if there are overwrites for this file apply them
+        if (typeof this._options.overwrites === "object" && this._options.overwrites[fontFileName]) {
+            font = extendExisting(font, this._options.overwrites[fontFileName]);
+        }
+
         this._data[fontIndex] = {
             font: font
           , fileName: fontFileName
@@ -279,12 +284,8 @@ define([
                         || font.names.fontFamily
                         ;
         fontFamily = fontFamily.split('-')[0];
-        
-        if (typeof this._options.overwrites === "object" && typeof this._options.overwrites[fontFamily] === "string") {
-                fontFamily = this._options.overwrites[fontFamily]
-        }
 
-        return fontFamily
+        return fontFamily;
     };
 
     _p._getOS2FontWeight = function(fontIndex) {
@@ -463,4 +464,20 @@ define([
 
     FontsData._installPublicCachedInterface(_p);
     return FontsData;
+
+
+    /**
+     * Overwrites (nested) properties in @param obj with values from @param ext
+     */
+    function extendExisting (obj, ext) {
+        for (var prop in ext) {
+            if (typeof ext[prop] === "object") {
+                prop = extendExisting(obj[prop], ext[prop]);
+            } else {
+                obj[prop] = ext[prop];
+            }
+        }
+        return obj;
+    }
+    
 });


### PR DESCRIPTION
An improvement to #23 that allows overwriting any arbitrary _font_ object data, for example the usWeightClass, as demonstrated in /examples/simple/main.js

This refactor still relies on only a dumb object passed in, so no closer to the API level solution you suggested, but somewhat more flexible in the meantime.